### PR TITLE
changes to make scripting with ontology2smw easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 # Ontology to SMW
 _**Automating an RDF ontology import into Semantic Mediawiki**_
 
-[Semantic Mediawiki](https://www.semantic-mediawiki.org)(SMW) allows 
-[external ontologies to be imported into a Mediawiki (MW) instance](https://www.semantic-mediawiki.org/wiki/Help:Import_vocabulary). 
-External ontology's properties and classes can be used inside the MW instance, and produce a RDF exports of 
+[Semantic Mediawiki](https://www.semantic-mediawiki.org)(SMW) allows
+[external ontologies to be imported into a Mediawiki (MW) instance](https://www.semantic-mediawiki.org/wiki/Help:Import_vocabulary).
+External ontology's properties and classes can be used inside the MW instance, and produce a RDF exports of
 the wiki pages, which point to IRIs of the imported ontology(s).
 
-The process of importing is simple, but time consuming. Hence making it a perfect candidate for an automated process, 
+The process of importing is simple, but time consuming. Hence making it a perfect candidate for an automated process,
 which can be run at anytime a new version of the ontology is published, hence this python script.
 
 Watch the [ontology2smw presentation](https://youtu.be/AQfJL-i6s88) at SMWCon 2020.
@@ -43,42 +43,44 @@ python setup.py install
 
 Using a remote ontology:<br/>`ontology2smw --format ttl --ontology https://raw.githubusercontent.com/tibonto/aeon/master/aeon.ttl`
 
-Writing to wiki pages:<br/>`ontology2smw --format ttl --ontology https://raw.githubusercontent.com/tibonto/aeon/master/aeon.ttl --write` 
+Writing to wiki pages:<br/>`ontology2smw --format ttl --ontology https://raw.githubusercontent.com/tibonto/aeon/master/aeon.ttl --write`
 
 Asking for help:<br/>`ontology2smw --help`
 ```bash
 usage: ontology2smw [-h] [-w] [-o ONTOLOGY] [-f {rdf,ttl}] [-v] [-r]
 
 
-                   ___    
-                 { . . } 
+                   ___
+                 { . . }
 --------------o00---'----00o--
-              ontology2SMW  
+              ontology2SMW
 -----------------------------
 
 optional arguments:
   -h, --help            show this help message and exit
   -w, --write           writes the output to wiki or file. Default: False (dry-run).
   -o ONTOLOGY, --ontology ONTOLOGY
-                        Ontology file or URI. Default: https://raw.githubusercontent.com/tibonto/aeon/master/aeon.ttl 
+                        Ontology file or URI. Default: https://raw.githubusercontent.com/tibonto/aeon/master/aeon.ttl
   -f {rdf,ttl}, --format {rdf,ttl}
                         Ontology format. Default value: ttl
   -v, --verbose         Verbose output. Default: False.
   -r, --report          Save report in file report.txt Default: False.
+  -s SETTINGS, --settings SETTINGS
+                        Use a wikidetails.yml file in a different location.
 
 
 ```
 
 <!--
 
-**Requirements:** 
+**Requirements:**
 
 In virtual environment install requirements `pip install -r requirements.txt`
 
 `python setup.py install`
 
 
-**Create a build:** 
+**Create a build:**
 
 `python setup.py sdist bdist_wheel`
 -->
@@ -88,23 +90,23 @@ In virtual environment install requirements `pip install -r requirements.txt`
 * Ensure user your wiki user account belongs to bot group: see wiki page `Special:UserRights`
 * Create a bot password in wiki page: `Special:BotPasswords`
 * **copy** `wikidetails.template.yml` as `wikidetails.yml` and fill in bot name and password:<br/>
-* **give the bot appropriate rights**: basic, editinterface, editpage, editprotected, createeditmovepage, highvolume    
+* **give the bot appropriate rights**: basic, editinterface, editpage, editprotected, createeditmovepage, highvolume
 
-The **local test VM**, mentioned in the following section, **sets a bot account for 
+The **local test VM**, mentioned in the following section, **sets a bot account for
 the Admin user**, so that once the VM is created **you can just run the script against it.**
 Details for that wiki, VM, bot username and password are set in `wikidetails.yml`
 
- 
-    
+
+
 ### Try on local Virtual Machine
-In order to test ontology2smw in action in a isolated virtual 
+In order to test ontology2smw in action in a isolated virtual
 environment, the repository includes a Ansible playbook which creates a VM with Mediawiki installed, and also creates a Bot account for wiki user Admin.
 
 The playbook sets Mediawiki with:
 * URL: http://192.168.100.100/w
 * SemanticMediawiki extension
 * bot account for Admin, with details (in wikidetail.yml):
-   * wiki user: Admin 
+   * wiki user: Admin
    * wiki user password: adminpassword
    * wiki bot: Admin@ontology2smwbot
    * wiki bot password: botpasswordbotpasswordbotpassword
@@ -113,7 +115,7 @@ The playbook sets Mediawiki with:
 Requirements:
 * [VirtualBox](https://www.virtualbox.org/)
 * [Vagrant](https://www.vagrantup.com/)
-* [Ansible](https://www.ansible.com/) 
+* [Ansible](https://www.ansible.com/)
 
 **Create VM:**
 ```bash
@@ -122,10 +124,10 @@ vagrant up
 ansible-playbook playbook_mw.yml
 ```
 Once tests are done you can either,
-* suspend the VM: `vagrant suspend` so it can be reused from the state it was left in with `vagrant up` 
+* suspend the VM: `vagrant suspend` so it can be reused from the state it was left in with `vagrant up`
 * destroy it: `vagrant destroy`
 
-    
+
 ## Develop
 
 ```bash
@@ -136,7 +138,7 @@ pip install -r requirements.txt
 python -m ontology2smw
 ```
 
-## Test 
+## Test
 
 **Tox:** automated testing on py36, py37, py38
 `tox -p all -v`

--- a/ontology2smw/__main__.py
+++ b/ontology2smw/__main__.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 from ontology2smw.cli_args import parser
 from ontology2smw.functions import writetowiki_decision
 from ontology2smw.functions import sparql2smwpage
@@ -14,8 +15,11 @@ def main():
     if args.write:
         writetowiki_decision()
 
+    # get base path of the code
+    base_path = Path(__file__).parent
+
     sparql2smwpage(
-        sparql_fn='ontology2smw/queries/ontology_terms.rq',
+        sparql_fn=base_path / 'queries' / 'ontology_terms.rq',
         format_=args.format,
         source=args.ontology,
     )

--- a/ontology2smw/cli_args.py
+++ b/ontology2smw/cli_args.py
@@ -2,10 +2,10 @@ from argparse import ArgumentParser, RawTextHelpFormatter
 
 parser = ArgumentParser(
     description="""
-                   ___    
-                 { . . } 
+                   ___
+                 { . . }
 --------------o00---'----00o--
-              ontology2SMW  
+              ontology2SMW
 -----------------------------""", formatter_class=RawTextHelpFormatter)
 parser.add_argument('-w', '--write', action='store_true',
                     help="writes the output to wiki or file. "
@@ -22,3 +22,5 @@ parser.add_argument('-v', '--verbose', action='store_true',
                     help="Verbose output. Default: False.")
 parser.add_argument('-r', '--report', action='store_true',
                     help="Save report in file report.txt Default: False.")
+parser.add_argument('-s', '--settings',
+                    help='Use a wikidetails.yml file in a different location.')

--- a/ontology2smw/functions.py
+++ b/ontology2smw/functions.py
@@ -105,7 +105,11 @@ def writetowiki_decision():
         "(If you say yes, make sure to disable cronjob for "
         "mediawiki/maintenance/runJobs.php) [yes/no]")
     if write_confirm == 'yes':
-        wikidetails = Path('.') / 'wikidetails.yml'
+        # use custom wikidetails.yml location
+        if args.settings:
+            wikidetails = Path(args.settings)
+        else:
+            wikidetails = Path('.') / 'wikidetails.yml'
         if Path.is_file(wikidetails) is False:
             print(f'No wikidetails.yml file was found in '
                   f'{wikidetails.absolute()}. Is is not possible to write'


### PR DESCRIPTION
- removed the hardcoded path from the __main__ function.
- added settings option (-s or --settings) to define custom location of the wikidetails yml file.
- made appropriate README changes.
- removed trailing spaces in the project

The project works just like before just now with the extra added settings option. I hope it is not too big of a deal. It is very useful to me. In addition, the file link in `__main__` meant that I could only activate the ontology2smw function if I was in the same folder as the ontologywsmw project. The change makes it so that the command can be called from anywhere.

Thanks for the awesome tool!